### PR TITLE
give bitwise operators separated precedences

### DIFF
--- a/biscuit-parser/src/parser.rs
+++ b/biscuit-parser/src/parser.rs
@@ -466,21 +466,30 @@ fn binary_op_1(i: &str) -> IResult<&str, builder::Binary, Error> {
 
 fn binary_op_2(i: &str) -> IResult<&str, builder::Binary, Error> {
     use builder::Binary;
-    alt((
-        value(Binary::Add, tag("+")),
-        value(Binary::Sub, tag("-")),
-        value(Binary::BitwiseAnd, tag("&")),
-        value(Binary::BitwiseOr, tag("|")),
-        value(Binary::BitwiseXor, tag("^")),
-    ))(i)
+    value(Binary::BitwiseXor, tag("^"))(i)
 }
 
 fn binary_op_3(i: &str) -> IResult<&str, builder::Binary, Error> {
     use builder::Binary;
-    alt((value(Binary::Mul, tag("*")), value(Binary::Div, tag("/"))))(i)
+    value(Binary::BitwiseOr, tag("|"))(i)
 }
 
 fn binary_op_4(i: &str) -> IResult<&str, builder::Binary, Error> {
+    use builder::Binary;
+    value(Binary::BitwiseAnd, tag("&"))(i)
+}
+
+fn binary_op_5(i: &str) -> IResult<&str, builder::Binary, Error> {
+    use builder::Binary;
+    alt((value(Binary::Add, tag("+")), value(Binary::Sub, tag("-"))))(i)
+}
+
+fn binary_op_6(i: &str) -> IResult<&str, builder::Binary, Error> {
+    use builder::Binary;
+    alt((value(Binary::Mul, tag("*")), value(Binary::Div, tag("/"))))(i)
+}
+
+fn binary_op_7(i: &str) -> IResult<&str, builder::Binary, Error> {
     use builder::Binary;
 
     alt((
@@ -537,10 +546,34 @@ fn expr3(i: &str) -> IResult<&str, Expr, Error> {
 }
 
 fn expr4(i: &str) -> IResult<&str, Expr, Error> {
+    let (i, initial) = expr5(i)?;
+
+    let (i, remainder) = many0(tuple((preceded(space0, binary_op_4), expr5)))(i)?;
+
+    Ok((i, fold_exprs(initial, remainder)))
+}
+
+fn expr5(i: &str) -> IResult<&str, Expr, Error> {
+    let (i, initial) = expr6(i)?;
+
+    let (i, remainder) = many0(tuple((preceded(space0, binary_op_5), expr6)))(i)?;
+
+    Ok((i, fold_exprs(initial, remainder)))
+}
+
+fn expr6(i: &str) -> IResult<&str, Expr, Error> {
+    let (i, initial) = expr7(i)?;
+
+    let (i, remainder) = many0(tuple((preceded(space0, binary_op_6), expr7)))(i)?;
+
+    Ok((i, fold_exprs(initial, remainder)))
+}
+
+fn expr7(i: &str) -> IResult<&str, Expr, Error> {
     let (i, initial) = expr_term(i)?;
 
     if let Ok((i, _)) = char::<_, ()>('.')(i) {
-        let (i, op) = binary_op_4(i)?;
+        let (i, op) = binary_op_7(i)?;
 
         let (i, _) = char('(')(i)?;
         let (i, _) = space0(i)?;
@@ -1330,6 +1363,24 @@ mod tests {
                     Op::Value(var("0")),
                     Op::Binary(Binary::Contains),
                     Op::Unary(Unary::Negate),
+                ],
+            ))
+        );
+
+        assert_eq!(
+            super::expr("1 + 2 | 4 * 3 & 4").map(|(i, o)| (i, o.opcodes())),
+            Ok((
+                "",
+                vec![
+                    Op::Value(int(1)),
+                    Op::Value(int(2)),
+                    Op::Binary(Binary::Add),
+                    Op::Value(int(4)),
+                    Op::Value(int(3)),
+                    Op::Binary(Binary::Mul),
+                    Op::Value(int(4)),
+                    Op::Binary(Binary::BitwiseAnd),
+                    Op::Binary(Binary::BitwiseOr),
                 ],
             ))
         );


### PR DESCRIPTION
To be consistent with other programming languages (like rust)